### PR TITLE
Start script does not need bash, and comment old URL.

### DIFF
--- a/mc-server.sh
+++ b/mc-server.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-URL="https://raw.githubusercontent.com/mc-server/MCServer/master/easyinstall.sh"
+#URL="https://raw.githubusercontent.com/mc-server/MCServer/master/easyinstall.sh"
 
 pushd /tmp/
 #curl -s "$URL" | sh
@@ -17,7 +17,7 @@ cp -r MCServer/. /home/mcuser/minecraft
 rm -rf MCServer
 popd
 
-echo '#!/bin/bash' > minecraft_server-run.sh
+echo '#!/bin/sh' > minecraft_server-run.sh
 echo "./MCServer" >> minecraft_server-run.sh
 chmod u+x minecraft_server-run.sh
 


### PR DESCRIPTION
The place where the URL is used is already commented out, and the MCServer start script has no need for bash, if sh is used it is more compatible.
