### PR TITLE
Update Cuberite download URL

### DIFF
--- a/cuberite.sh
+++ b/cuberite.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-URL="http://builds.cuberite.org/job/Cuberite%20Linux%20x64%20Master/lastSuccessfulBuild/artifact/Cuberite.tar.gz"
+URL="https://download.cuberite.org/linux-x86_64/Cuberite.tar.gz"
 
 rm -rf cuberite.tar.gz
 wget -O cuberite.tar.gz "$URL"


### PR DESCRIPTION
Cuberite has recently gained a redirect server for download links. Now this download location is robust against changes to the buildserver or main project URL.