### PR TITLE
Adds support for Forge server installs for versions 1.13 and up

### DIFF
--- a/forge.sh
+++ b/forge.sh
@@ -8,12 +8,10 @@ set -e
 
 FORGE_VERSION="$MINECRAFT_FLAVOUR_VERSION"
 FORGE_INSTALLER="forge-$FORGE_VERSION-installer.jar"
-FORGE_UNIVERSAL="forge-$FORGE_VERSION-universal.jar"
 URL="http://files.minecraftforge.net/maven/net/minecraftforge/forge/$FORGE_VERSION/$FORGE_INSTALLER"
 
 rm -f "$FORGE_INSTALLER"
 wget -O "$FORGE_INSTALLER" "$URL"
 java -jar "$FORGE_INSTALLER" --installServer
-mv "$FORGE_UNIVERSAL" minecraft_server-run.jar
 echo "eula=true" > eula.txt
 echo "enable-query=true" > server.properties

--- a/forge_new.sh
+++ b/forge_new.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # script author: Raekye
-# server: Minecraft Forge
+# server: Minecraft Forge 1.13+
 # project developers: Minecraft Forge team
 # project website: http://minecraftforge.net
 
@@ -8,12 +8,12 @@ set -e
 
 FORGE_VERSION="$MINECRAFT_FLAVOUR_VERSION"
 FORGE_INSTALLER="forge-$FORGE_VERSION-installer.jar"
-FORGE_UNIVERSAL="forge-$FORGE_VERSION-universal.jar"
+FORGE_SERVER="forge-$FORGE_VERSION.jar"
 URL="http://files.minecraftforge.net/maven/net/minecraftforge/forge/$FORGE_VERSION/$FORGE_INSTALLER"
 
 rm -f "$FORGE_INSTALLER"
 wget -O "$FORGE_INSTALLER" "$URL"
 java -jar "$FORGE_INSTALLER" --installServer
-mv "$FORGE_UNIVERSAL" minecraft_server-run.jar
+mv "$FORGE_SERVER" minecraft_server-run.jar
 echo "eula=true" > eula.txt
 echo "enable-query=true" > server.properties


### PR DESCRIPTION
Forge for Minecraft v1.13.2 changed the way that server installs happen. This PR adds an install script to handle this.
Related to [this PR](https://github.com/Gamocosm/Gamocosm/pull/139). Tested this for v1.13.2 and v1.16.4. Assume the versions in between also work.